### PR TITLE
Adding third part of apns

### DIFF
--- a/AlpsSDK/AlpsManager/AlpsManager+Convenience.swift
+++ b/AlpsSDK/AlpsManager/AlpsManager+Convenience.swift
@@ -39,4 +39,11 @@ extension AlpsManager {
             completion?(result)
         }
     }
+    
+    public func createPinDevice(device: PinDevice, completion: ((Result<PinDevice?>) -> Void)? = nil) {
+        pinDevices.create(item: device) { (result) in
+           completion?(result)
+        }
+    }
+
 }

--- a/AlpsSDK/AlpsManager/AlpsManager.swift
+++ b/AlpsSDK/AlpsManager/AlpsManager.swift
@@ -31,10 +31,11 @@ public class AlpsManager: MatchMonitorDelegate, ContextManagerDelegate {
     public lazy var contextManager = ContextManager(delegate: self)
     public lazy var matchMonitor = MatchMonitor(delegate: self)
     public var remoteNotificationManager: RemoteNotificationManager!
-    var onMatch: ((_ matches: [Match], _ device: Device) -> Void)?
+    public var onMatch: ((_ matches: [Match], _ device: Device) -> Void)?
     
     public lazy var mobileDevices = MobileDeviceRepository()
     public lazy var pinDevices = PinDeviceRepository()
+    public lazy var beaconDevices = BeaconRepository()
     
     public lazy var publications = PublicationRepository()
     public lazy var subscriptions = SubscriptionRepository()

--- a/AlpsSDK/AlpsManager/AlpsManager.swift
+++ b/AlpsSDK/AlpsManager/AlpsManager.swift
@@ -30,7 +30,7 @@ public class AlpsManager: MatchMonitorDelegate, ContextManagerDelegate {
     
     public lazy var contextManager = ContextManager(delegate: self)
     public lazy var matchMonitor = MatchMonitor(delegate: self)
-    public let remoteNotificationManager: RemoteNotificationManager = RemoteNotificationManager()
+    public var remoteNotificationManager: RemoteNotificationManager!
     var onMatch: ((_ matches: [Match], _ device: Device) -> Void)?
     
     public lazy var mobileDevices = MobileDeviceRepository()
@@ -47,6 +47,7 @@ public class AlpsManager: MatchMonitorDelegate, ContextManagerDelegate {
         if let baseURL = baseURL {
             self.baseURL = baseURL
         }
+        remoteNotificationManager = RemoteNotificationManager(delegate: matchMonitor)
     }
     
     private func setupAPI() {

--- a/AlpsSDK/ContextManager.swift
+++ b/AlpsSDK/ContextManager.swift
@@ -42,7 +42,7 @@ public class ContextManager: NSObject, CLLocationManagerDelegate {
 
     // MARK: - Beacons
     
-    func startRanging(forUuid: UUID, identifier: String) {
+    public func startRanging(forUuid: UUID, identifier: String) {
         let beaconRegion = CLBeaconRegion(proximityUUID: forUuid, identifier: identifier)
         locationManager.startRangingBeacons(in: beaconRegion)
     }

--- a/AlpsSDK/MatchMonitor.swift
+++ b/AlpsSDK/MatchMonitor.swift
@@ -13,7 +13,8 @@ protocol MatchMonitorDelegate: class {
     func didFind(matches: [Match], for device: Device)
 }
 
-public class MatchMonitor {
+public class MatchMonitor: RemoteNotificationManagerDelegate {
+    
     private(set) weak var delegate: MatchMonitorDelegate?
     private(set) var monitoredDevices = Set<Device>()
     private(set) var deliveredMatches = Set<Match>()
@@ -55,6 +56,15 @@ public class MatchMonitor {
             guard let matches = matches, matches.count > 0, error == nil else { return }
             self.deliveredMatches = Set(matches)
             self.delegate?.didFind(matches: matches, for: device)
+        }
+    }
+    
+    // When MatchMonitor receive a notification(push or ws) it will get the matches for the monitored devices.
+    internal func remoteNotificationManager(manager: RemoteNotificationManager, didReceiveNotification: String) {
+        monitoredDevices.forEach {
+            if $0.id == didReceiveNotification {
+                getMatchesForDevice(device: $0)
+            }
         }
     }
 }

--- a/AlpsSDK/ModelExtensions.swift
+++ b/AlpsSDK/ModelExtensions.swift
@@ -75,7 +75,7 @@ public extension Subscription {
 }
 
 public extension Location {
-    internal convenience init(latitude: Double, longitude: Double, altitude: Double? = nil, horizontalAccuracy: Double? = nil, verticalAccuracy: Double? = nil) {
+    public convenience init(latitude: Double, longitude: Double, altitude: Double? = nil, horizontalAccuracy: Double? = nil, verticalAccuracy: Double? = nil) {
         self.init()
         self.latitude = latitude
         self.longitude = longitude

--- a/AlpsSDK/ProximityHandler.swift
+++ b/AlpsSDK/ProximityHandler.swift
@@ -121,7 +121,9 @@ final class ProximityHandler: ProximityHandlerDelegate {
                 }
                 return false
             }
-            result.append(b[0])
+            if !b.isEmpty {
+                result.append(b[0])
+            }
         }
         return result
     }

--- a/AlpsSDK/RemoteNotificationManager.swift
+++ b/AlpsSDK/RemoteNotificationManager.swift
@@ -6,18 +6,24 @@
 //  Copyright © 2017 Alps. All rights reserved.
 //
 
-import Foundation
 import UserNotifications
+import UIKit
+
+protocol RemoteNotificationManagerDelegate: class {
+    func remoteNotificationManager(manager: RemoteNotificationManager, didReceiveNotification: String)
+}
 
 public class RemoteNotificationManager: NSObject, UNUserNotificationCenterDelegate {
     
+    private weak var delegate: RemoteNotificationManagerDelegate?
     var deviceTokenData: Data?
     public lazy var deviceToken: String = {
         return self.deviceTokenData?.reduce("", {$0 + String(format: "%02X", $1)})
         }()!
     
-    override init() {
+    init(delegate: RemoteNotificationManagerDelegate) {
         super.init()
+        self.delegate = delegate
         registerForPushNotifications()
     }
     
@@ -65,14 +71,16 @@ public class RemoteNotificationManager: NSObject, UNUserNotificationCenterDelega
         // Called when app is open in background and click on notification
         NSLog("did Receive function : ")
         NSLog(response.notification.request.content.body)
+        delegate?.remoteNotificationManager(manager: self, didReceiveNotification: response.notification.request.content.body)
         completionHandler()
     }
     
     @available(iOS 10.0, *)
     public func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         // Called when app is in foreground
-        // Assume that the request.content.body contains the match id.
+        // Assume that the request.content.body contains the device id.
         NSLog("will present function : ")
         NSLog(notification.request.content.body)
+        delegate?.remoteNotificationManager(manager: self, didReceiveNotification: notification.request.content.body)
     }
 }

--- a/AlpsSDK/Repositories/Devices/BeaconRepository.swift
+++ b/AlpsSDK/Repositories/Devices/BeaconRepository.swift
@@ -11,9 +11,9 @@ import Alps
 
 let kBeaconFile = "kBeaconFile.Alps"
 
-final class BeaconRepository: AsyncReadable {
+final public class BeaconRepository: AsyncReadable {
     typealias DataType = IBeaconTriple
-    private(set) var items = [IBeaconTriple]() {
+    public var items = [IBeaconTriple]() {
         didSet {
             _ = PersistenceManager.save(object: self.items.map { $0.encodableIBeaconTriple }, to: kBeaconFile)
         }
@@ -24,14 +24,14 @@ final class BeaconRepository: AsyncReadable {
         updateBeaconTriplets()
     }
     
-    func find(byId: String, completion: @escaping (Result<IBeaconTriple?>) -> Void) {
+    public func find(byId: String, completion: @escaping (Result<IBeaconTriple?>) -> Void) {
         completion(.success(items.filter { $0.deviceId == byId }.first))
         updateBeaconTriplets {
             completion(.success(self.items.filter { $0.deviceId == byId }.first))
         }
     }
     
-    func findAll(completion: @escaping (Result<[IBeaconTriple]>) -> Void) {
+    public func findAll(completion: @escaping (Result<[IBeaconTriple]>) -> Void) {
         completion(.success(items))
         updateBeaconTriplets {
             completion(.success(self.items))

--- a/AlpsSDK/Repositories/PubSub/PublicationRepository.swift
+++ b/AlpsSDK/Repositories/PubSub/PublicationRepository.swift
@@ -36,15 +36,15 @@ final public class PublicationRepository: AsyncCreateable, AsyncReadable, AsyncD
         }
     }
     
-    func find(byId: String, completion: @escaping (Result<Publication?>) -> Void) {
+    public func find(byId: String, completion: @escaping (Result<Publication?>) -> Void) {
         completion(.success(items.filter { $0.id == byId }.first))
     }
     
-    func findAll(completion: @escaping (Result<[Publication]>) -> Void) {
+    public func findAll(completion: @escaping (Result<[Publication]>) -> Void) {
         completion(.success(items))
     }
     
-    func delete(item: Publication, completion: @escaping (ErrorResponse?) -> Void) {
+    public func delete(item: Publication, completion: @escaping (ErrorResponse?) -> Void) {
         guard let id = item.id else { completion(ErrorResponse.missingId); return }
         guard let deviceId = item.deviceId else { completion(ErrorResponse.missingId); return }
         self.items = self.items.filter { $0 !== item }
@@ -53,7 +53,7 @@ final public class PublicationRepository: AsyncCreateable, AsyncReadable, AsyncD
         })
     }
     
-    func deleteAll() {
+    public func deleteAll() {
         items.forEach { self.delete(item: $0, completion: { (_) in }) }
         items = []
     }


### PR DESCRIPTION
Receiving notification deviceId and delegates it to matchMonitor to get the matches for this specific deviceId

known issue : 
- Each notification, concerns one and only one deviceId **for the moment** -> TO DO : We could have an array of deviceId. But if it is the case we need to create our own parser and build the array. I need to have a closer look at UNNotificationResponse and UNNotification.

I kept it simple, for this first try.
